### PR TITLE
Default to @{u} in git-fixup-changelogs

### DIFF
--- a/git-fixup-changelogs
+++ b/git-fixup-changelogs
@@ -1,12 +1,12 @@
 #!/bin/sh
 
 if test -z "$1"; then
-    echo "usage: git fixup-changelogs BASE-REVISION" 1>&2
-    exit 1
+    base_rev=@{u}
+else
+    base_rev="$1"
 fi
 
 dir=$(git rev-parse --git-dir)
-base_rev="$1"
 
 GIT_EDITOR='perl -pi -e s/pick/edit/' git rebase -i "$base_rev"
 


### PR DESCRIPTION
I'm almost always going to want to fixup starting from the upstream branch; was there a reason you didn't want to use that as a default?